### PR TITLE
toml: Move assert_cmd crate to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,8 @@ serde_json = "1.0"
 clap = "2.31"
 proc-mounts = "0.2.2"
 libc = "0.2.72"
-assert_cmd = "0.12"
 quote = "=1.0.1"
 libseccomp = "0.1.1"
+
+[dev-dependencies]
+assert_cmd = "0.12"


### PR DESCRIPTION
The assert_cmd crate is used in only the test code, so the crate should be moved to dev-dependencies in Cargo.toml.