### PR TITLE
workflows: Fix sudo github workflows error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,16 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Prepare for libseccomp
       run: sudo apt-get install libseccomp-dev
     
-    - name: rustup
-      run: sudo -E /usr/share/rust/.cargo/bin/rustup default stable
-
     - name: Build
       run: cargo build --verbose
 
     - name: Run tests
-      run: sudo -E /usr/share/rust/.cargo/bin/cargo test --verbose
+      run: CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' cargo test --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build Release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Prepare for libseccomp
       run: sudo apt-get install libseccomp-dev
@@ -21,7 +21,7 @@ jobs:
       run: cargo build --release --verbose
 
     - name: Run Tests
-      run: sudo /usr/share/rust/.cargo/bin/cargo test --verbose
+      run: CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' cargo test --verbose
 
     - run: mkdir artifact
     - run: tar -czf  artifact/oci-ftrace-syscall-analyzer-amd64.tar.gz -C target/release/ oci-ftrace-syscall-analyzer


### PR DESCRIPTION
- Use v3 version and remove sudo dependency
- Cargo test has to be run with sudo to access `debugfs`
```
$ mount | grep debugfs
debugfs on /sys/kernel/debug type debugfs (rw,relatime)
```
- Build pass reference
  - https://github.com/chethanah/oci-ftrace-syscall-analyzer/actions/runs/4538635293/jobs/7997729515 